### PR TITLE
fix Azure NIC bug

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -531,6 +531,9 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                     ) for ip_config in self.ip_configurations
                 ]
 
+                if not nsg and self.security_group_name:
+                    nsg = self.get_security_group(self.security_group_name)
+
                 nsg = nsg or self.create_default_securitygroup(self.resource_group, self.location, self.name, self.os_type, self.open_ports)
                 self.log('Creating or updating network interface {0}'.format(self.name))
                 nic = self.network_models.NetworkInterface(


### PR DESCRIPTION
##### SUMMARY
**Issue:** `azure_rm_networkinterface` was ignoring the `security_group_name` property if the network interface did not exist
**Cause:** Code that applies `security_group_name` was within the same try block as an exception that is always thrown if the NIC does not exist (exception thrown on line 457, property applied starting line 471)
**Solution:** Check for NSG again before creating the default

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_networkinterface

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/nelson/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.3 (default, Oct  6 2017, 08:44:35) [GCC 5.4.0 20160609]
```